### PR TITLE
optimizing cairo steps and memory holes cost

### DIFF
--- a/src/contracts/zklink.cairo
+++ b/src/contracts/zklink.cairo
@@ -1863,8 +1863,7 @@ mod Zklink {
             _chainId: u8,
             _pubData: @Bytes,
             _pubdataOffset: usize,
-            _nextPriorityOpIdx: u64,
-        // _ethWitness: @Bytes
+            _nextPriorityOpIdx: u64
         ) -> (u64, Bytes, Bytes) {
             let mut priorityOperationsProcessed: u64 = 0;
             let mut processablePubData: Bytes = BytesTrait::new();

--- a/src/contracts/zklink.cairo
+++ b/src/contracts/zklink.cairo
@@ -1904,13 +1904,7 @@ mod Zklink {
                     + priorityOperationsProcessed;
 
                 let (newPriorityProceeded, opPubData, processablePubData) = self
-                    .checkOnchainOp(
-                        opType,
-                        chainId,
-                        pubData,
-                        pubdataOffset,
-                        nextPriorityOpIndex,
-                        onchainOpData.ethWitness
+                    .checkOnchainOp(opType, chainId, pubData, pubdataOffset, nextPriorityOpIndex,// onchainOpData.ethWitness
                     );
 
                 priorityOperationsProcessed += newPriorityProceeded;
@@ -1942,7 +1936,7 @@ mod Zklink {
             _pubData: @Bytes,
             _pubdataOffset: usize,
             _nextPriorityOpIdx: u64,
-            _ethWitness: @Bytes
+        // _ethWitness: @Bytes
         ) -> (u64, Bytes, Bytes) {
             let mut priorityOperationsProcessed: u64 = 0;
             let mut processablePubData: Bytes = BytesTrait::new();

--- a/src/contracts/zklink.cairo
+++ b/src/contracts/zklink.cairo
@@ -1768,7 +1768,9 @@ mod Zklink {
                 .collectOnchainOps(_newBlock);
 
             // Create block commitment for verification proof
-            let commitment: u256 = createBlockCommitment(_previousBlock, _newBlock, _newBlockExtra);
+            let commitmentForSync: u256 = createBlockCommitmentForSync(
+                _previousBlock, _newBlock, _newBlockExtra
+            );
 
             // Create synchronization hash for cross chain block verify
             let onchainOpPubdataHashs: Array<u256> = buildOnchainOperationPubdataHashs(
@@ -1776,7 +1778,7 @@ mod Zklink {
             );
 
             let syncHash = createSyncHash(
-                *_previousBlock.syncHash, commitment, @onchainOpPubdataHashs
+                *_previousBlock.syncHash, commitmentForSync, @onchainOpPubdataHashs
             );
 
             StoredBlockInfo {
@@ -1785,7 +1787,7 @@ mod Zklink {
                 pendingOnchainOperationsHash: pendingOnchainOpsHash,
                 timestamp: *_newBlock.timestamp,
                 stateHash: *_newBlock.newStateHash,
-                commitment: commitment,
+                commitment: 0,
                 syncHash: syncHash
             }
         }
@@ -2226,7 +2228,7 @@ mod Zklink {
 
     // Creates block commitment from its data
     // _offsetCommitment - hash of the array where 1 is stored in chunk where onchainOperation begins and 0 for other chunks
-    fn createBlockCommitment(
+    fn createBlockCommitmentForSync(
         _previousBlock: @StoredBlockInfo,
         _newBlockData: @CommitBlockInfo,
         _newBlockExtraData: @CompressedBlockExtraInfo,

--- a/src/contracts/zklink.cairo
+++ b/src/contracts/zklink.cairo
@@ -2304,7 +2304,9 @@ mod Zklink {
     // Creates block commitment from its data
     // _offsetCommitment - hash of the array where 1 is stored in chunk where onchainOperation begins and 0 for other chunks
     fn createProofBlockCommitment(
-        _previousBlock: @StoredBlockInfo, _newBlockData: @CommitBlockInfo, _offsetsCommitment: @Bytes
+        _previousBlock: @StoredBlockInfo,
+        _newBlockData: @CommitBlockInfo,
+        _offsetsCommitment: @Bytes
     ) -> u256 {
         let offsetsCommitmentHash = _offsetsCommitment.sha256();
         let newBlockPubDataHash = _newBlockData.publicData.sha256();

--- a/src/tests/mocks/zklink_test.cairo
+++ b/src/tests/mocks/zklink_test.cairo
@@ -79,7 +79,7 @@ trait IZklinkMock<TContractState> {
     fn getPendingBalance(self: @TContractState, _address: u256, _tokenId: u16) -> u128;
     fn mockExecBlock(self: @TContractState, _storedBlockInfo: StoredBlockInfo);
     fn testCollectOnchainOps(
-        self: @TContractState, _newBlockData: CommitBlockInfo
+        self: @TContractState, _newBlockData: CommitBlockInfo, _compressed: bool
     ) -> (u256, u64, Bytes, Array<u256>);
     fn testAddPriorityRequest(self: @TContractState, _opType: OpType, _opData: Bytes);
     fn testCommitOneBlock(
@@ -334,10 +334,10 @@ mod ZklinkMock {
         }
 
         fn testCollectOnchainOps(
-            self: @ContractState, _newBlockData: CommitBlockInfo
+            self: @ContractState, _newBlockData: CommitBlockInfo, _compressed: bool
         ) -> (u256, u64, Bytes, Array<u256>) {
             let state: Zklink::ContractState = Zklink::contract_state_for_testing();
-            Zklink::InternalFunctions::collectOnchainOps(@state, @_newBlockData)
+            Zklink::InternalFunctions::collectOnchainOps(@state, @_newBlockData, _compressed)
         }
 
         fn testAddPriorityRequest(self: @ContractState, _opType: OpType, _opData: Bytes) {

--- a/src/tests/mocks/zklink_test.cairo
+++ b/src/tests/mocks/zklink_test.cairo
@@ -79,14 +79,13 @@ trait IZklinkMock<TContractState> {
     fn getPendingBalance(self: @TContractState, _address: u256, _tokenId: u16) -> u128;
     fn mockExecBlock(self: @TContractState, _storedBlockInfo: StoredBlockInfo);
     fn testCollectOnchainOps(
-        self: @TContractState, _newBlockData: CommitBlockInfo, _compressed: bool
-    ) -> (u256, u64, Bytes, Array<u256>);
+        self: @TContractState, _newBlockData: CommitBlockInfo
+    ) -> (u256, u64, u256);
     fn testAddPriorityRequest(self: @TContractState, _opType: OpType, _opData: Bytes);
     fn testCommitOneBlock(
         self: @TContractState,
         _previousBlock: StoredBlockInfo,
         _newBlock: CommitBlockInfo,
-        _compressed: bool,
         _newBlockExtra: CompressedBlockExtraInfo
     ) -> StoredBlockInfo;
     fn testExecuteWithdraw(self: @TContractState, _op: Withdraw);
@@ -334,10 +333,10 @@ mod ZklinkMock {
         }
 
         fn testCollectOnchainOps(
-            self: @ContractState, _newBlockData: CommitBlockInfo, _compressed: bool
-        ) -> (u256, u64, Bytes, Array<u256>) {
+            self: @ContractState, _newBlockData: CommitBlockInfo
+        ) -> (u256, u64, u256) {
             let state: Zklink::ContractState = Zklink::contract_state_for_testing();
-            Zklink::InternalFunctions::collectOnchainOps(@state, @_newBlockData, _compressed)
+            Zklink::InternalFunctions::collectOnchainOps(@state, @_newBlockData)
         }
 
         fn testAddPriorityRequest(self: @ContractState, _opType: OpType, _opData: Bytes) {
@@ -349,12 +348,11 @@ mod ZklinkMock {
             self: @ContractState,
             _previousBlock: StoredBlockInfo,
             _newBlock: CommitBlockInfo,
-            _compressed: bool,
             _newBlockExtra: CompressedBlockExtraInfo
         ) -> StoredBlockInfo {
             let mut state: Zklink::ContractState = Zklink::contract_state_for_testing();
             Zklink::InternalFunctions::commitOneBlock(
-                ref state, @_previousBlock, @_newBlock, _compressed, @_newBlockExtra
+                ref state, @_previousBlock, @_newBlock, @_newBlockExtra
             )
         }
 

--- a/src/tests/test_block_commit.cairo
+++ b/src/tests/test_block_commit.cairo
@@ -42,7 +42,7 @@ fn test_zklink_collectOnchainOps_invalid_pubdata_length1() {
         feeAccount: 0
     };
 
-    dispatcher.testCollectOnchainOps(block);
+    dispatcher.testCollectOnchainOps(block, true);
 }
 
 #[test]
@@ -67,7 +67,7 @@ fn test_zklink_collectOnchainOps_invalid_pubdata_length2() {
         feeAccount: 0
     };
 
-    dispatcher.testCollectOnchainOps(block);
+    dispatcher.testCollectOnchainOps(block, true);
 }
 
 #[test]
@@ -90,14 +90,10 @@ fn test_zklink_collectOnchainOps_no_pubdata() {
         feeAccount: 0
     };
 
-    let (
-        processableOperationsHash,
-        priorityOperationsProcessed,
-        offsetsCommitment,
-        onchainOperationPubdataHashs
-    ) =
+    let (processableOperationsHash, priorityOperationsProcessed, offsetsCommitment,
+    onchainOperationPubdataHashs) =
         dispatcher
-        .testCollectOnchainOps(block);
+        .testCollectOnchainOps(block, true);
 
     assert(processableOperationsHash == EMPTY_STRING_KECCAK, 'invalid value 0');
     assert(priorityOperationsProcessed == 0, 'invalid value 1');
@@ -135,14 +131,7 @@ fn test_zklink_collectOnchainOps_invalid_pubdata_offset1() {
         feeAccount: 0
     };
 
-    let (
-        processableOperationsHash,
-        priorityOperationsProcessed,
-        offsetsCommitment,
-        onchainOperationPubdataHashs
-    ) =
-        dispatcher
-        .testCollectOnchainOps(block);
+    dispatcher.testCollectOnchainOps(block, true);
 }
 
 #[test]
@@ -171,14 +160,7 @@ fn test_zklink_collectOnchainOps_invalid_pubdata_offset2() {
         feeAccount: 0
     };
 
-    let (
-        processableOperationsHash,
-        priorityOperationsProcessed,
-        offsetsCommitment,
-        onchainOperationPubdataHashs
-    ) =
-        dispatcher
-        .testCollectOnchainOps(block);
+    dispatcher.testCollectOnchainOps(block, true);
 }
 
 #[test]
@@ -207,14 +189,7 @@ fn test_zklink_collectOnchainOps_invalid_pubdata_offset3() {
         feeAccount: 0
     };
 
-    let (
-        processableOperationsHash,
-        priorityOperationsProcessed,
-        offsetsCommitment,
-        onchainOperationPubdataHashs
-    ) =
-        dispatcher
-        .testCollectOnchainOps(block);
+    dispatcher.testCollectOnchainOps(block, true);
 }
 
 #[test]
@@ -243,14 +218,7 @@ fn test_zklink_collectOnchainOps_invalid_op_type() {
         feeAccount: 0
     };
 
-    let (
-        processableOperationsHash,
-        priorityOperationsProcessed,
-        offsetsCommitment,
-        onchainOperationPubdataHashs
-    ) =
-        dispatcher
-        .testCollectOnchainOps(block);
+    dispatcher.testCollectOnchainOps(block, true);
 }
 
 // calculate pubData from Python
@@ -304,14 +272,7 @@ fn test_zklink_collectOnchainOps_invalid_chain_id1() {
         feeAccount: 0
     };
 
-    let (
-        processableOperationsHash,
-        priorityOperationsProcessed,
-        offsetsCommitment,
-        onchainOperationPubdataHashs
-    ) =
-        dispatcher
-        .testCollectOnchainOps(block);
+    dispatcher.testCollectOnchainOps(block, true);
 }
 
 #[test]
@@ -354,14 +315,7 @@ fn test_zklink_collectOnchainOps_invalid_chain_id2() {
         feeAccount: 0
     };
 
-    let (
-        processableOperationsHash,
-        priorityOperationsProcessed,
-        offsetsCommitment,
-        onchainOperationPubdataHashs
-    ) =
-        dispatcher
-        .testCollectOnchainOps(block);
+    dispatcher.testCollectOnchainOps(block, true);
 }
 
 #[test]
@@ -417,14 +371,7 @@ fn test_zklink_collectOnchainOps_duplicate_pubdata_offset() {
         feeAccount: 0
     };
 
-    let (
-        processableOperationsHash,
-        priorityOperationsProcessed,
-        offsetsCommitment,
-        onchainOperationPubdataHashs
-    ) =
-        dispatcher
-        .testCollectOnchainOps(block);
+    dispatcher.testCollectOnchainOps(block, false);
 }
 
 #[test]
@@ -817,7 +764,7 @@ fn test_zklink_collectOnchainOps_success() {
         actual_onchainOperationPubdataHashs
     ) =
         dispatcher
-        .testCollectOnchainOps(block);
+        .testCollectOnchainOps(block, false);
 
     assert(actual_processableOperationsHash == processableOpPubdataHash, 'invaid value1');
     assert(actual_priorityOperationsProcessed == priorityOperationsProcessed, 'invaid value2');
@@ -1320,8 +1267,8 @@ fn test_zklink_testCommitOneBlock_commit_compressed_block() {
     };
 
     let extraBlock = CompressedBlockExtraInfo {
-        publicDataHash: pubdatas.sha256(),
-        offsetCommitmentHash: offsetsCommitment.sha256(),
+        publicDataHash: pubdatas.keccak(),
+        offsetCommitmentHash: offsetsCommitment.keccak(),
         onchainOperationPubdataHashs: array![
             0,
             onchainOpPubdataHash1,

--- a/src/tests/test_block_commit.cairo
+++ b/src/tests/test_block_commit.cairo
@@ -9,7 +9,7 @@ use starknet::Felt252TryIntoContractAddress;
 use zklink::tests::mocks::zklink_test::ZklinkMock;
 use zklink::tests::mocks::zklink_test::IZklinkMockDispatcher;
 use zklink::tests::mocks::zklink_test::IZklinkMockDispatcherTrait;
-use zklink::contracts::zklink::Zklink::{createSyncHash, createBlockCommitment};
+use zklink::contracts::zklink::Zklink::{createSyncHash, createBlockCommitmentForSync};
 use zklink::utils::data_structures::DataStructures::{
     CommitBlockInfo, OnchainOperationData, StoredBlockInfo, CompressedBlockExtraInfo
 };
@@ -836,7 +836,7 @@ fn test_zklink_testCommitOneBlock_commit_compressed_block() {
         ]
     };
 
-    let commitment = createBlockCommitment(@preBlock, @compressedBlock, @extraBlock);
+    let commitment = createBlockCommitmentForSync(@preBlock, @compressedBlock, @extraBlock);
 
     let r1: StoredBlockInfo = dispatcher.testCommitOneBlock(preBlock, compressedBlock, extraBlock);
 
@@ -845,7 +845,7 @@ fn test_zklink_testCommitOneBlock_commit_compressed_block() {
     assert(r1.pendingOnchainOperationsHash == processableOpPubdataHash, 'invaid value3');
     assert(r1.timestamp == timestamp, 'invaid value4');
     assert(r1.stateHash == newStateHash, 'invaid value5');
-    assert(r1.commitment == commitment, 'invaid value6');
+    assert(r1.commitment == 0, 'invaid value6');
     assert(r1.syncHash.low == 0xf592534d947803bd7707e40ec34a185b, 'invaid value7');
     assert(r1.syncHash.high == 0x415190de4c2749e44e1565072210a8fa, 'invaid value7');
 }

--- a/src/tests/test_block_commit.cairo
+++ b/src/tests/test_block_commit.cairo
@@ -114,9 +114,7 @@ fn test_zklink_collectOnchainOps_invalid_pubdata_offset1() {
     publicData.append_u8(0x00);
     utils::paddingChunk(ref publicData, utils::OP_NOOP_CHUNKS);
 
-    let onchainOperation = OnchainOperationData { // ethWitness: BytesTrait::new(),
-        publicDataOffset: publicData.size()
-    };
+    let onchainOperation = OnchainOperationData { publicDataOffset: publicData.size() };
     let onchainOperations: Array<OnchainOperationData> = array![onchainOperation];
 
     let mut block = CommitBlockInfo {
@@ -143,9 +141,7 @@ fn test_zklink_collectOnchainOps_invalid_pubdata_offset2() {
     publicData.append_u8(0x00);
     utils::paddingChunk(ref publicData, utils::OP_NOOP_CHUNKS);
 
-    let onchainOperation = OnchainOperationData { // ethWitness: BytesTrait::new(),
-        publicDataOffset: 1
-    };
+    let onchainOperation = OnchainOperationData { publicDataOffset: 1 };
     let onchainOperations: Array<OnchainOperationData> = array![onchainOperation];
 
     let mut block = CommitBlockInfo {
@@ -172,9 +168,7 @@ fn test_zklink_collectOnchainOps_invalid_pubdata_offset3() {
     publicData.append_u8(0x00);
     utils::paddingChunk(ref publicData, utils::OP_NOOP_CHUNKS);
 
-    let onchainOperation = OnchainOperationData { // ethWitness: BytesTrait::new(),
-        publicDataOffset: CHUNK_BYTES - 2
-    };
+    let onchainOperation = OnchainOperationData { publicDataOffset: CHUNK_BYTES - 2 };
     let onchainOperations: Array<OnchainOperationData> = array![onchainOperation];
 
     let mut block = CommitBlockInfo {
@@ -201,9 +195,7 @@ fn test_zklink_collectOnchainOps_invalid_op_type() {
     publicData.append_u16(0x0001);
     utils::paddingChunk(ref publicData, utils::OP_NOOP_CHUNKS);
 
-    let onchainOperation = OnchainOperationData { // ethWitness: BytesTrait::new(),
-        publicDataOffset: 0
-    };
+    let onchainOperation = OnchainOperationData { publicDataOffset: 0 };
     let onchainOperations: Array<OnchainOperationData> = array![onchainOperation];
 
     let mut block = CommitBlockInfo {
@@ -255,9 +247,7 @@ fn test_zklink_collectOnchainOps_invalid_chain_id1() {
 
     utils::paddingChunk(ref publicData, utils::OP_DEPOSIT_CHUNKS);
 
-    let onchainOperation = OnchainOperationData { // ethWitness: BytesTrait::new(),
-        publicDataOffset: 0
-    };
+    let onchainOperation = OnchainOperationData { publicDataOffset: 0 };
     let onchainOperations: Array<OnchainOperationData> = array![onchainOperation];
 
     let mut block = CommitBlockInfo {
@@ -298,9 +288,7 @@ fn test_zklink_collectOnchainOps_invalid_chain_id2() {
     };
     utils::paddingChunk(ref publicData, utils::OP_DEPOSIT_CHUNKS);
 
-    let onchainOperation = OnchainOperationData { // ethWitness: BytesTrait::new(),
-        publicDataOffset: 0
-    };
+    let onchainOperation = OnchainOperationData { publicDataOffset: 0 };
     let onchainOperations: Array<OnchainOperationData> = array![onchainOperation];
 
     let mut block = CommitBlockInfo {
@@ -368,18 +356,8 @@ fn test_zklink_collectOnchainOps_success() {
     pubdatas.concat(@op);
     pubdatasOfChain1.concat(@op);
     onchainOpPubdataHash1 = concatHash(onchainOpPubdataHash1, @op);
-    ops
-        .append(
-            OnchainOperationData { // ethWitness: BytesTrait::new(),
-                publicDataOffset: publicDataOffset
-            }
-        );
-    opsOfChain1
-        .append(
-            OnchainOperationData { // ethWitness: BytesTrait::new(),
-                publicDataOffset: publicDataOffsetOfChain1
-            }
-        );
+    ops.append(OnchainOperationData { publicDataOffset: publicDataOffset });
+    opsOfChain1.append(OnchainOperationData { publicDataOffset: publicDataOffsetOfChain1 });
     publicDataOffset += op.size();
     publicDataOffsetOfChain1 += op.size();
     priorityOperationsProcessed += 1;
@@ -406,18 +384,8 @@ fn test_zklink_collectOnchainOps_success() {
     pubdatasOfChain1.concat(@op);
     onchainOpPubdataHash1 = concatHash(onchainOpPubdataHash1, @op);
     processableOpPubdataHash = concatHash(processableOpPubdataHash, @op);
-    ops
-        .append(
-            OnchainOperationData { // ethWitness: BytesTrait::new(),
-                publicDataOffset: publicDataOffset
-            }
-        );
-    opsOfChain1
-        .append(
-            OnchainOperationData { // ethWitness: BytesTrait::new(),
-                publicDataOffset: publicDataOffsetOfChain1
-            }
-        );
+    ops.append(OnchainOperationData { publicDataOffset: publicDataOffset });
+    opsOfChain1.append(OnchainOperationData { publicDataOffset: publicDataOffsetOfChain1 });
     publicDataOffset += op.size();
     publicDataOffsetOfChain1 += op.size();
 
@@ -458,18 +426,8 @@ fn test_zklink_collectOnchainOps_success() {
     pubdatasOfChain1.concat(@op);
     onchainOpPubdataHash1 = concatHash(onchainOpPubdataHash1, @op);
     processableOpPubdataHash = concatHash(processableOpPubdataHash, @op);
-    ops
-        .append(
-            OnchainOperationData { // ethWitness: BytesTrait::new(),
-                publicDataOffset: publicDataOffset
-            }
-        );
-    opsOfChain1
-        .append(
-            OnchainOperationData { // ethWitness: BytesTrait::new(),
-                publicDataOffset: publicDataOffsetOfChain1
-            }
-        );
+    ops.append(OnchainOperationData { publicDataOffset: publicDataOffset });
+    opsOfChain1.append(OnchainOperationData { publicDataOffset: publicDataOffsetOfChain1 });
     publicDataOffset += op.size();
     publicDataOffsetOfChain1 += op.size();
     priorityOperationsProcessed += 1;
@@ -496,18 +454,8 @@ fn test_zklink_collectOnchainOps_success() {
     pubdatasOfChain1.concat(@op);
     onchainOpPubdataHash1 = concatHash(onchainOpPubdataHash1, @op);
     processableOpPubdataHash = concatHash(processableOpPubdataHash, @op);
-    ops
-        .append(
-            OnchainOperationData { // ethWitness: BytesTrait::new(),
-                publicDataOffset: publicDataOffset
-            }
-        );
-    opsOfChain1
-        .append(
-            OnchainOperationData { // ethWitness: BytesTrait::new(),
-                publicDataOffset: publicDataOffsetOfChain1
-            }
-        );
+    ops.append(OnchainOperationData { publicDataOffset: publicDataOffset });
+    opsOfChain1.append(OnchainOperationData { publicDataOffset: publicDataOffsetOfChain1 });
     publicDataOffset += op.size();
 
     let mut block = CommitBlockInfo {
@@ -660,18 +608,8 @@ fn test_zklink_testCommitOneBlock_commit_compressed_block() {
     pubdatas.concat(@op);
     pubdatasOfChain1.concat(@op);
     onchainOpPubdataHash1 = concatHash(onchainOpPubdataHash1, @op);
-    ops
-        .append(
-            OnchainOperationData { // ethWitness: BytesTrait::new(),
-                publicDataOffset: publicDataOffset
-            }
-        );
-    opsOfChain1
-        .append(
-            OnchainOperationData { // ethWitness: BytesTrait::new(),
-                publicDataOffset: publicDataOffsetOfChain1
-            }
-        );
+    ops.append(OnchainOperationData { publicDataOffset: publicDataOffset });
+    opsOfChain1.append(OnchainOperationData { publicDataOffset: publicDataOffsetOfChain1 });
     publicDataOffset += op.size();
     publicDataOffsetOfChain1 += op.size();
     priorityOperationsProcessed += 1;
@@ -699,18 +637,8 @@ fn test_zklink_testCommitOneBlock_commit_compressed_block() {
     pubdatasOfChain1.concat(@op);
     onchainOpPubdataHash1 = concatHash(onchainOpPubdataHash1, @op);
     processableOpPubdataHash = concatHash(processableOpPubdataHash, @op);
-    ops
-        .append(
-            OnchainOperationData { // ethWitness: BytesTrait::new(),
-                publicDataOffset: publicDataOffset
-            }
-        );
-    opsOfChain1
-        .append(
-            OnchainOperationData { // ethWitness: BytesTrait::new(),
-                publicDataOffset: publicDataOffsetOfChain1
-            }
-        );
+    ops.append(OnchainOperationData { publicDataOffset: publicDataOffset });
+    opsOfChain1.append(OnchainOperationData { publicDataOffset: publicDataOffsetOfChain1 });
     publicDataOffset += op.size();
     publicDataOffsetOfChain1 += op.size();
     utils::createOffsetCommitment(ref offsetsCommitment, @op, true);
@@ -752,18 +680,8 @@ fn test_zklink_testCommitOneBlock_commit_compressed_block() {
     pubdatasOfChain1.concat(@op);
     onchainOpPubdataHash1 = concatHash(onchainOpPubdataHash1, @op);
     processableOpPubdataHash = concatHash(processableOpPubdataHash, @op);
-    ops
-        .append(
-            OnchainOperationData { // ethWitness: BytesTrait::new(),
-                publicDataOffset: publicDataOffset
-            }
-        );
-    opsOfChain1
-        .append(
-            OnchainOperationData { // ethWitness: BytesTrait::new(),
-                publicDataOffset: publicDataOffsetOfChain1
-            }
-        );
+    ops.append(OnchainOperationData { publicDataOffset: publicDataOffset });
+    opsOfChain1.append(OnchainOperationData { publicDataOffset: publicDataOffsetOfChain1 });
     publicDataOffset += op.size();
     publicDataOffsetOfChain1 += op.size();
     priorityOperationsProcessed += 1;
@@ -791,18 +709,8 @@ fn test_zklink_testCommitOneBlock_commit_compressed_block() {
     pubdatasOfChain1.concat(@op);
     onchainOpPubdataHash1 = concatHash(onchainOpPubdataHash1, @op);
     processableOpPubdataHash = concatHash(processableOpPubdataHash, @op);
-    ops
-        .append(
-            OnchainOperationData { // ethWitness: BytesTrait::new(),
-                publicDataOffset: publicDataOffset
-            }
-        );
-    opsOfChain1
-        .append(
-            OnchainOperationData { // ethWitness: BytesTrait::new(),
-                publicDataOffset: publicDataOffsetOfChain1
-            }
-        );
+    ops.append(OnchainOperationData { publicDataOffset: publicDataOffset });
+    opsOfChain1.append(OnchainOperationData { publicDataOffset: publicDataOffsetOfChain1 });
     publicDataOffset += op.size();
     utils::createOffsetCommitment(ref offsetsCommitment, @op, true);
 

--- a/src/tests/test_block_commit.cairo
+++ b/src/tests/test_block_commit.cairo
@@ -90,8 +90,12 @@ fn test_zklink_collectOnchainOps_no_pubdata() {
         feeAccount: 0
     };
 
-    let (processableOperationsHash, priorityOperationsProcessed, offsetsCommitment,
-    onchainOperationPubdataHashs) =
+    let (
+        processableOperationsHash,
+        priorityOperationsProcessed,
+        offsetsCommitment,
+        onchainOperationPubdataHashs
+    ) =
         dispatcher
         .testCollectOnchainOps(block, true);
 

--- a/src/tests/test_block_commit.cairo
+++ b/src/tests/test_block_commit.cairo
@@ -9,6 +9,7 @@ use starknet::Felt252TryIntoContractAddress;
 use zklink::tests::mocks::zklink_test::ZklinkMock;
 use zklink::tests::mocks::zklink_test::IZklinkMockDispatcher;
 use zklink::tests::mocks::zklink_test::IZklinkMockDispatcherTrait;
+use zklink::contracts::zklink::Zklink::{createSyncHash, createBlockCommitment};
 use zklink::utils::data_structures::DataStructures::{
     CommitBlockInfo, OnchainOperationData, StoredBlockInfo, CompressedBlockExtraInfo
 };
@@ -42,7 +43,7 @@ fn test_zklink_collectOnchainOps_invalid_pubdata_length1() {
         feeAccount: 0
     };
 
-    dispatcher.testCollectOnchainOps(block, true);
+    dispatcher.testCollectOnchainOps(block);
 }
 
 #[test]
@@ -67,7 +68,7 @@ fn test_zklink_collectOnchainOps_invalid_pubdata_length2() {
         feeAccount: 0
     };
 
-    dispatcher.testCollectOnchainOps(block, true);
+    dispatcher.testCollectOnchainOps(block);
 }
 
 #[test]
@@ -91,22 +92,14 @@ fn test_zklink_collectOnchainOps_no_pubdata() {
     };
 
     let (
-        processableOperationsHash,
-        priorityOperationsProcessed,
-        offsetsCommitment,
-        onchainOperationPubdataHashs
+        processableOperationsHash, priorityOperationsProcessed, currentnchainOperationPubdataHash
     ) =
         dispatcher
-        .testCollectOnchainOps(block, true);
+        .testCollectOnchainOps(block);
 
     assert(processableOperationsHash == EMPTY_STRING_KECCAK, 'invalid value 0');
     assert(priorityOperationsProcessed == 0, 'invalid value 1');
-    assert(offsetsCommitment.size() == 0, 'invalid value 2');
-    assert(*onchainOperationPubdataHashs[0] == 0, 'invalid value 3');
-    assert(*onchainOperationPubdataHashs[1] == EMPTY_STRING_KECCAK, 'invalid value 3');
-    assert(*onchainOperationPubdataHashs[2] == EMPTY_STRING_KECCAK, 'invalid value 4');
-    assert(*onchainOperationPubdataHashs[3] == EMPTY_STRING_KECCAK, 'invalid value 5');
-    assert(*onchainOperationPubdataHashs[4] == EMPTY_STRING_KECCAK, 'invalid value 6');
+    assert(currentnchainOperationPubdataHash == EMPTY_STRING_KECCAK, 'invalid value 3');
 }
 
 #[test]
@@ -122,7 +115,8 @@ fn test_zklink_collectOnchainOps_invalid_pubdata_offset1() {
     utils::paddingChunk(ref publicData, utils::OP_NOOP_CHUNKS);
 
     let onchainOperation = OnchainOperationData { // ethWitness: BytesTrait::new(),
-    publicDataOffset: publicData.size() };
+        publicDataOffset: publicData.size()
+    };
     let onchainOperations: Array<OnchainOperationData> = array![onchainOperation];
 
     let mut block = CommitBlockInfo {
@@ -134,7 +128,7 @@ fn test_zklink_collectOnchainOps_invalid_pubdata_offset1() {
         feeAccount: 0
     };
 
-    dispatcher.testCollectOnchainOps(block, true);
+    dispatcher.testCollectOnchainOps(block);
 }
 
 #[test]
@@ -150,7 +144,8 @@ fn test_zklink_collectOnchainOps_invalid_pubdata_offset2() {
     utils::paddingChunk(ref publicData, utils::OP_NOOP_CHUNKS);
 
     let onchainOperation = OnchainOperationData { // ethWitness: BytesTrait::new(),
-    publicDataOffset: 1 };
+        publicDataOffset: 1
+    };
     let onchainOperations: Array<OnchainOperationData> = array![onchainOperation];
 
     let mut block = CommitBlockInfo {
@@ -162,7 +157,7 @@ fn test_zklink_collectOnchainOps_invalid_pubdata_offset2() {
         feeAccount: 0
     };
 
-    dispatcher.testCollectOnchainOps(block, true);
+    dispatcher.testCollectOnchainOps(block);
 }
 
 #[test]
@@ -178,7 +173,8 @@ fn test_zklink_collectOnchainOps_invalid_pubdata_offset3() {
     utils::paddingChunk(ref publicData, utils::OP_NOOP_CHUNKS);
 
     let onchainOperation = OnchainOperationData { // ethWitness: BytesTrait::new(),
-    publicDataOffset: CHUNK_BYTES - 2 };
+        publicDataOffset: CHUNK_BYTES - 2
+    };
     let onchainOperations: Array<OnchainOperationData> = array![onchainOperation];
 
     let mut block = CommitBlockInfo {
@@ -190,7 +186,7 @@ fn test_zklink_collectOnchainOps_invalid_pubdata_offset3() {
         feeAccount: 0
     };
 
-    dispatcher.testCollectOnchainOps(block, true);
+    dispatcher.testCollectOnchainOps(block);
 }
 
 #[test]
@@ -206,7 +202,8 @@ fn test_zklink_collectOnchainOps_invalid_op_type() {
     utils::paddingChunk(ref publicData, utils::OP_NOOP_CHUNKS);
 
     let onchainOperation = OnchainOperationData { // ethWitness: BytesTrait::new(),
-    publicDataOffset: 0 };
+        publicDataOffset: 0
+    };
     let onchainOperations: Array<OnchainOperationData> = array![onchainOperation];
 
     let mut block = CommitBlockInfo {
@@ -218,7 +215,7 @@ fn test_zklink_collectOnchainOps_invalid_op_type() {
         feeAccount: 0
     };
 
-    dispatcher.testCollectOnchainOps(block, true);
+    dispatcher.testCollectOnchainOps(block);
 }
 
 // calculate pubData from Python
@@ -259,7 +256,8 @@ fn test_zklink_collectOnchainOps_invalid_chain_id1() {
     utils::paddingChunk(ref publicData, utils::OP_DEPOSIT_CHUNKS);
 
     let onchainOperation = OnchainOperationData { // ethWitness: BytesTrait::new(),
-    publicDataOffset: 0 };
+        publicDataOffset: 0
+    };
     let onchainOperations: Array<OnchainOperationData> = array![onchainOperation];
 
     let mut block = CommitBlockInfo {
@@ -271,7 +269,7 @@ fn test_zklink_collectOnchainOps_invalid_chain_id1() {
         feeAccount: 0
     };
 
-    dispatcher.testCollectOnchainOps(block, true);
+    dispatcher.testCollectOnchainOps(block);
 }
 
 #[test]
@@ -301,7 +299,8 @@ fn test_zklink_collectOnchainOps_invalid_chain_id2() {
     utils::paddingChunk(ref publicData, utils::OP_DEPOSIT_CHUNKS);
 
     let onchainOperation = OnchainOperationData { // ethWitness: BytesTrait::new(),
-    publicDataOffset: 0 };
+        publicDataOffset: 0
+    };
     let onchainOperations: Array<OnchainOperationData> = array![onchainOperation];
 
     let mut block = CommitBlockInfo {
@@ -313,64 +312,7 @@ fn test_zklink_collectOnchainOps_invalid_chain_id2() {
         feeAccount: 0
     };
 
-    dispatcher.testCollectOnchainOps(block, true);
-}
-
-#[test]
-#[available_gas(20000000000)]
-#[should_panic(expected: ('h3', 'ENTRYPOINT_FAILED'))]
-fn test_zklink_collectOnchainOps_duplicate_pubdata_offset() {
-    let (addrs, _) = utils::prepare_test_deploy();
-    let zklink = *addrs[6];
-    let dispatcher = IZklinkMockDispatcher { contract_address: zklink };
-    // depositData0 and depositData1
-    // encode_format = ["uint8","uint8","uint32","uint8","uint16","uint16","uint128","uint256"]
-    // example = [1, 2, 1, 0, 33, 33, 500, 0x74a0c0f8e8756218a96c2d9aae21152d786a0704202b10fb30496e46222b72d]
-    //
-    // data = [1339612589503194456358419569248829440, 549787120963470, 179892997260459296479640320015568236610]
-    // pending_data = 3254000107459431534606125
-    // pending_data_size = 11
-
-    let mut depositData0 = Bytes {
-        data: array![
-            1339612589503194456358419569248829440,
-            549787120963470,
-            179892997260459296479640320015568236610
-        ],
-        pending_data: 3254000107459431534606125,
-        pending_data_size: 11
-    };
-    let mut depositData1 = Bytes {
-        data: array![
-            1339612589503194456358419569248829440,
-            549787120963470,
-            179892997260459296479640320015568236610
-        ],
-        pending_data: 3254000107459431534606125,
-        pending_data_size: 11
-    };
-
-    utils::paddingChunk(ref depositData0, utils::OP_DEPOSIT_CHUNKS);
-    utils::paddingChunk(ref depositData1, utils::OP_DEPOSIT_CHUNKS);
-
-    depositData0.concat(@depositData1);
-
-    let onchainOperations: Array<OnchainOperationData> = array![
-        OnchainOperationData { // ethWitness: BytesTrait::new(),
-        publicDataOffset: 0 }, OnchainOperationData { // ethWitness: BytesTrait::new(),
-        publicDataOffset: 0 }
-    ];
-
-    let mut block = CommitBlockInfo {
-        newStateHash: 0xbb66ffc06a476f05a218f6789ca8946e4f0cf29f1efc2e4d0f9a8e70f0326313,
-        publicData: depositData0,
-        timestamp: 1652422395,
-        onchainOperations: onchainOperations,
-        blockNumber: 10,
-        feeAccount: 0
-    };
-
-    dispatcher.testCollectOnchainOps(block, false);
+    dispatcher.testCollectOnchainOps(block);
 }
 
 #[test]
@@ -384,15 +326,11 @@ fn test_zklink_collectOnchainOps_success() {
     let mut pubdatasOfChain1: Bytes = BytesTrait::new();
     let mut ops: Array<OnchainOperationData> = array![];
     let mut opsOfChain1: Array<OnchainOperationData> = array![];
-    // no op of chain 2
     let mut onchainOpPubdataHash1: u256 = EMPTY_STRING_KECCAK;
-    let mut onchainOpPubdataHash3: u256 = EMPTY_STRING_KECCAK;
-    let mut onchainOpPubdataHash4: u256 = EMPTY_STRING_KECCAK;
     let mut publicDataOffset: usize = 0;
     let mut publicDataOffsetOfChain1: usize = 0;
     let mut priorityOperationsProcessed: u64 = 0;
     let mut processableOpPubdataHash: u256 = EMPTY_STRING_KECCAK;
-    let mut offsetsCommitment: Bytes = BytesTrait::new();
 
     // deposit of current chain(chain 1)
     // encode_format = ["uint8","uint8","uint32","uint8","uint16","uint16","uint128","uint256"]
@@ -430,141 +368,21 @@ fn test_zklink_collectOnchainOps_success() {
     pubdatas.concat(@op);
     pubdatasOfChain1.concat(@op);
     onchainOpPubdataHash1 = concatHash(onchainOpPubdataHash1, @op);
-    ops.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
-    publicDataOffset: publicDataOffset });
-    opsOfChain1.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
-    publicDataOffset: publicDataOffsetOfChain1 });
+    ops
+        .append(
+            OnchainOperationData { // ethWitness: BytesTrait::new(),
+                publicDataOffset: publicDataOffset
+            }
+        );
+    opsOfChain1
+        .append(
+            OnchainOperationData { // ethWitness: BytesTrait::new(),
+                publicDataOffset: publicDataOffsetOfChain1
+            }
+        );
     publicDataOffset += op.size();
     publicDataOffsetOfChain1 += op.size();
     priorityOperationsProcessed += 1;
-    utils::createOffsetCommitment(ref offsetsCommitment, @op, true);
-
-    // change pubkey of chain 3
-    // encode_format = ["uint8","uint8","uint32","uint8","uint160","uint256","uint32","uint16","uint16"]
-    // example = [6, 3, 2, 0, 0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, 0x74a0c0f8e8756218a96c2d9aae21152d786a0704202b10fb30496e46222b72d, 32, 37, 145]
-    //
-    // data = [7990944865287520720191985022115949226, 226854911280625642308916404252811464590, 179892997260459296479640320015568236610, 3577810954935998486498406173769736192]
-    // pending_data = 2424977
-    // pending_data_size = 3
-    let mut op = Bytes {
-        data: array![
-            7990944865287520720191985022115949226,
-            226854911280625642308916404252811464590,
-            179892997260459296479640320015568236610,
-            3577810954935998486498406173769736192
-        ],
-        pending_data: 2424977,
-        pending_data_size: 3
-    };
-    utils::paddingChunk(ref op, utils::OP_CHANGE_PUBKEY_CHUNKS);
-    pubdatas.concat(@op);
-    onchainOpPubdataHash3 = concatHash(onchainOpPubdataHash3, @op);
-    ops.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
-    publicDataOffset: publicDataOffset });
-    publicDataOffset += op.size();
-    utils::createOffsetCommitment(ref offsetsCommitment, @op, true);
-
-    // transfer of chain 4
-    // encode_format = ["uint8","uint32","uint8","uint16","uint40","uint32","uint8","uint16"]
-    // example = [4, 1, 0, 33, 456, 4, 3, 34]
-    //
-    // data = [5316911983449149110179127749911773184]
-    // pending_data = 67305506
-    // pending_data_size = 4
-    let mut op = Bytes {
-        data: array![5316911983449149110179127749911773184],
-        pending_data: 67305506,
-        pending_data_size: 4
-    };
-    utils::paddingChunk(ref op, utils::OP_TRANSFER_CHUNKS);
-    pubdatas.concat(@op);
-    publicDataOffset += op.size();
-    utils::createOffsetCommitment(ref offsetsCommitment, @op, false);
-
-    // deposit of chain4
-    // encode_format = ["uint8","uint8","uint32","uint8","uint16","uint16","uint128","uint256"]
-    // example = [1, 4, 3, 6, 35, 35, 345, 0x74a0c0f8e8756218a96c2d9aae21152d786a0704202b10fb30496e46222b72d]
-    //
-    // data = [1349997183222710297597724425227075584, 379362818658190, 179892997260459296479640320015568236610]
-    // pending_data = 3254000107459431534606125
-    // pending_data_size = 11
-    let mut op = Bytes {
-        data: array![
-            1349997183222710297597724425227075584,
-            379362818658190,
-            179892997260459296479640320015568236610
-        ],
-        pending_data: 3254000107459431534606125,
-        pending_data_size: 11
-    };
-    utils::paddingChunk(ref op, utils::OP_DEPOSIT_CHUNKS);
-    pubdatas.concat(@op);
-    onchainOpPubdataHash4 = concatHash(onchainOpPubdataHash4, @op);
-    ops.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
-    publicDataOffset: publicDataOffset });
-    publicDataOffset += op.size();
-    utils::createOffsetCommitment(ref offsetsCommitment, @op, true);
-
-    // full exit of chain4
-    // encode_format = ["uint8","uint8","uint32","uint8","uint256","uint16","uint16","uint128"]
-    // example = [5, 4, 43, 2, 0x5D8E9F533DA8993FC200826F21D0b88F33f53c2a2a151016FD18dA7a77eEb0c, 35, 35, 245]
-    //
-    // data = [6666909166410712037873566033893757948, 42577624153754863967194330481103536495, 278544165408887043319642418119171899392]
-    // pending_data = 245
-    // pending_data_size = 11
-    let mut op = Bytes {
-        data: array![
-            6666909166410712037873566033893757948,
-            42577624153754863967194330481103536495,
-            278544165408887043319642418119171899392
-        ],
-        pending_data: 245,
-        pending_data_size: 11
-    };
-    utils::paddingChunk(ref op, utils::OP_FULL_EXIT_CHUNKS);
-    pubdatas.concat(@op);
-    onchainOpPubdataHash4 = concatHash(onchainOpPubdataHash4, @op);
-    ops.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
-    publicDataOffset: publicDataOffset });
-    publicDataOffset += op.size();
-    utils::createOffsetCommitment(ref offsetsCommitment, @op, true);
-
-    // mock Noop
-    // encode_format = ["uint8"]
-    // example = [0]
-    //
-    // data = []
-    // pending_data_size = 1
-    let mut op = Bytes { data: array![], pending_data: 1, pending_data_size: 1 };
-    utils::paddingChunk(ref op, utils::OP_NOOP_CHUNKS);
-    pubdatas.concat(@op);
-    publicDataOffset += op.size();
-    utils::createOffsetCommitment(ref offsetsCommitment, @op, false);
-
-    // force exit of chain3
-    // encode_format = ["uint8","uint8","uint32","uint8","uint32","uint32","uint8","uint16","uint16","uint128","uint256"]
-    // example = [7, 3, 30, 7, 3, 43, 2, 35, 35, 245, 0x74a0c0f8e8756218a96c2d9aae21152d786a0704202b10fb30496e46222b72d]
-    //
-    // data = [9320172861106316424366063172242647810, 181733163034406966250383145560965120, 19413155728529532836176956146393, 227142569737839188506614686513323349732]
-    // pending_data = 1646442285
-    // pending_data_size = 4
-    let mut op = Bytes {
-        data: array![
-            9320172861106316424366063172242647810,
-            181733163034406966250383145560965120,
-            19413155728529532836176956146393,
-            227142569737839188506614686513323349732
-        ],
-        pending_data: 1646442285,
-        pending_data_size: 4
-    };
-    utils::paddingChunk(ref op, utils::OP_FORCE_EXIT_CHUNKS);
-    pubdatas.concat(@op);
-    onchainOpPubdataHash3 = concatHash(onchainOpPubdataHash3, @op);
-    ops.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
-    publicDataOffset: publicDataOffset });
-    publicDataOffset += op.size();
-    utils::createOffsetCommitment(ref offsetsCommitment, @op, true);
 
     // withdraw of current chain(chain 1)
     // encode_format = ["uint8","uint8","uint32","uint8","uint16","uint16","uint128","uint16","uint256","uint32","uint16","uint8"]
@@ -588,13 +406,20 @@ fn test_zklink_collectOnchainOps_success() {
     pubdatasOfChain1.concat(@op);
     onchainOpPubdataHash1 = concatHash(onchainOpPubdataHash1, @op);
     processableOpPubdataHash = concatHash(processableOpPubdataHash, @op);
-    ops.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
-    publicDataOffset: publicDataOffset });
-    opsOfChain1.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
-    publicDataOffset: publicDataOffsetOfChain1 });
+    ops
+        .append(
+            OnchainOperationData { // ethWitness: BytesTrait::new(),
+                publicDataOffset: publicDataOffset
+            }
+        );
+    opsOfChain1
+        .append(
+            OnchainOperationData { // ethWitness: BytesTrait::new(),
+                publicDataOffset: publicDataOffsetOfChain1
+            }
+        );
     publicDataOffset += op.size();
     publicDataOffsetOfChain1 += op.size();
-    utils::createOffsetCommitment(ref offsetsCommitment, @op, true);
 
     // full exit of current chain
     // encode_format = ["uint8","uint8","uint32","uint8","uint256","uint16","uint16","uint128"]
@@ -633,14 +458,21 @@ fn test_zklink_collectOnchainOps_success() {
     pubdatasOfChain1.concat(@op);
     onchainOpPubdataHash1 = concatHash(onchainOpPubdataHash1, @op);
     processableOpPubdataHash = concatHash(processableOpPubdataHash, @op);
-    ops.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
-    publicDataOffset: publicDataOffset });
-    opsOfChain1.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
-    publicDataOffset: publicDataOffsetOfChain1 });
+    ops
+        .append(
+            OnchainOperationData { // ethWitness: BytesTrait::new(),
+                publicDataOffset: publicDataOffset
+            }
+        );
+    opsOfChain1
+        .append(
+            OnchainOperationData { // ethWitness: BytesTrait::new(),
+                publicDataOffset: publicDataOffsetOfChain1
+            }
+        );
     publicDataOffset += op.size();
     publicDataOffsetOfChain1 += op.size();
     priorityOperationsProcessed += 1;
-    utils::createOffsetCommitment(ref offsetsCommitment, @op, true);
 
     // force exit of current chain
     // encode_format = ["uint8","uint8","uint32","uint8","uint32","uint32","uint8","uint16","uint16","uint128","uint256"]
@@ -664,36 +496,19 @@ fn test_zklink_collectOnchainOps_success() {
     pubdatasOfChain1.concat(@op);
     onchainOpPubdataHash1 = concatHash(onchainOpPubdataHash1, @op);
     processableOpPubdataHash = concatHash(processableOpPubdataHash, @op);
-    ops.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
-    publicDataOffset: publicDataOffset });
-    opsOfChain1.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
-    publicDataOffset: publicDataOffsetOfChain1 });
+    ops
+        .append(
+            OnchainOperationData { // ethWitness: BytesTrait::new(),
+                publicDataOffset: publicDataOffset
+            }
+        );
+    opsOfChain1
+        .append(
+            OnchainOperationData { // ethWitness: BytesTrait::new(),
+                publicDataOffset: publicDataOffsetOfChain1
+            }
+        );
     publicDataOffset += op.size();
-    utils::createOffsetCommitment(ref offsetsCommitment, @op, true);
-
-    // withdraw of chain 4
-    // encode_format = ["uint8","uint8","uint32","uint8","uint16","uint16","uint128","uint16","uint256","uint32","uint16","uint8"]
-    // example = [3, 4, 15, 5, 34, 34, 1000, 33, 0x5D8E9F533DA8993FC200826F21D0b88F33f53c2a2a151016FD18dA7a77eEb0c, 14, 50, 0]
-    //
-    // data = [4008453174807044430802172532689469440, 1099512181807337, 325930098572440622605242809423852945235, 258714655159228338356975277813679521792]
-    // pending_data = 234893824
-    // pending_data_size = 4
-    let mut op = Bytes {
-        data: array![
-            4008453174807044430802172532689469440,
-            1099512181807337,
-            325930098572440622605242809423852945235,
-            258714655159228338356975277813679521792
-        ],
-        pending_data: 234893824,
-        pending_data_size: 4
-    };
-    utils::paddingChunk(ref op, utils::OP_WITHDRAW_CHUNKS);
-    pubdatas.concat(@op);
-    onchainOpPubdataHash4 = concatHash(onchainOpPubdataHash4, @op);
-    ops.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
-    publicDataOffset: publicDataOffset });
-    utils::createOffsetCommitment(ref offsetsCommitment, @op, true);
 
     let mut block = CommitBlockInfo {
         newStateHash: 0xbb66ffc06a476f05a218f6789ca8946e4f0cf29f1efc2e4d0f9a8e70f0326313,
@@ -707,24 +522,14 @@ fn test_zklink_collectOnchainOps_success() {
     let (
         actual_processableOperationsHash,
         actual_priorityOperationsProcessed,
-        actual_offsetsCommitment,
-        actual_onchainOperationPubdataHashs
+        actual_currentOnchainOperationPubdataHashs
     ) =
         dispatcher
-        .testCollectOnchainOps(block, false);
+        .testCollectOnchainOps(block);
 
     assert(actual_processableOperationsHash == processableOpPubdataHash, 'invaid value1');
     assert(actual_priorityOperationsProcessed == priorityOperationsProcessed, 'invaid value2');
-    assert(actual_offsetsCommitment.size() == offsetsCommitment.size(), 'invaid value3');
-    assert(*actual_offsetsCommitment.data[0] == *offsetsCommitment.data[0], 'invaid value4');
-    assert(
-        actual_offsetsCommitment.pending_data == offsetsCommitment.pending_data, 'invaid value5'
-    );
-    assert(*actual_onchainOperationPubdataHashs[0] == 0, 'invaid value6');
-    assert(*actual_onchainOperationPubdataHashs[1] == onchainOpPubdataHash1, 'invaid value7');
-    assert(*actual_onchainOperationPubdataHashs[2] == EMPTY_STRING_KECCAK, 'invaid value8');
-    assert(*actual_onchainOperationPubdataHashs[3] == onchainOpPubdataHash3, 'invaid value9');
-    assert(*actual_onchainOperationPubdataHashs[4] == onchainOpPubdataHash4, 'invaid value10');
+    assert(actual_currentOnchainOperationPubdataHashs == onchainOpPubdataHash1, 'invaid value7');
 }
 
 
@@ -761,7 +566,7 @@ fn test_zklink_testCommitOneBlock_invalid_block_number() {
 
     commitBlock.blockNumber = 12;
 
-    dispatcher.testCommitOneBlock(preBlock, commitBlock, false, extraBlock);
+    dispatcher.testCommitOneBlock(preBlock, commitBlock, extraBlock);
 }
 
 #[test]
@@ -798,7 +603,7 @@ fn test_zklink_testCommitOneBlock_invalid_timestamp() {
     commitBlock.timestamp = preBlock.timestamp - 1;
     preBlock.timestamp = preBlock.timestamp + 1;
 
-    dispatcher.testCommitOneBlock(preBlock, commitBlock, false, extraBlock);
+    dispatcher.testCommitOneBlock(preBlock, commitBlock, extraBlock);
 }
 
 #[test]
@@ -812,10 +617,7 @@ fn test_zklink_testCommitOneBlock_commit_compressed_block() {
     let mut pubdatasOfChain1: Bytes = BytesTrait::new();
     let mut ops: Array<OnchainOperationData> = array![];
     let mut opsOfChain1: Array<OnchainOperationData> = array![];
-    // no op of chain 2
     let mut onchainOpPubdataHash1: u256 = EMPTY_STRING_KECCAK;
-    let mut onchainOpPubdataHash3: u256 = EMPTY_STRING_KECCAK;
-    let mut onchainOpPubdataHash4: u256 = EMPTY_STRING_KECCAK;
     let mut publicDataOffset: usize = 0;
     let mut publicDataOffsetOfChain1: usize = 0;
     let mut priorityOperationsProcessed: u64 = 0;
@@ -858,140 +660,21 @@ fn test_zklink_testCommitOneBlock_commit_compressed_block() {
     pubdatas.concat(@op);
     pubdatasOfChain1.concat(@op);
     onchainOpPubdataHash1 = concatHash(onchainOpPubdataHash1, @op);
-    ops.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
-    publicDataOffset: publicDataOffset });
-    opsOfChain1.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
-    publicDataOffset: publicDataOffsetOfChain1 });
+    ops
+        .append(
+            OnchainOperationData { // ethWitness: BytesTrait::new(),
+                publicDataOffset: publicDataOffset
+            }
+        );
+    opsOfChain1
+        .append(
+            OnchainOperationData { // ethWitness: BytesTrait::new(),
+                publicDataOffset: publicDataOffsetOfChain1
+            }
+        );
     publicDataOffset += op.size();
     publicDataOffsetOfChain1 += op.size();
     priorityOperationsProcessed += 1;
-    utils::createOffsetCommitment(ref offsetsCommitment, @op, true);
-
-    // change pubkey of chain 3
-    // encode_format = ["uint8","uint8","uint32","uint8","uint160","uint256","uint32","uint16","uint16"]
-    // example = [6, 3, 2, 0, 0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, 0x74a0c0f8e8756218a96c2d9aae21152d786a0704202b10fb30496e46222b72d, 32, 37, 145]
-    //
-    // data = [7990944865287520720191985022115949226, 226854911280625642308916404252811464590, 179892997260459296479640320015568236610, 3577810954935998486498406173769736192]
-    // pending_data = 2424977
-    // pending_data_size = 3
-    let mut op = Bytes {
-        data: array![
-            7990944865287520720191985022115949226,
-            226854911280625642308916404252811464590,
-            179892997260459296479640320015568236610,
-            3577810954935998486498406173769736192
-        ],
-        pending_data: 2424977,
-        pending_data_size: 3
-    };
-    utils::paddingChunk(ref op, utils::OP_CHANGE_PUBKEY_CHUNKS);
-    pubdatas.concat(@op);
-    onchainOpPubdataHash3 = concatHash(onchainOpPubdataHash3, @op);
-    ops.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
-    publicDataOffset: publicDataOffset });
-    publicDataOffset += op.size();
-    utils::createOffsetCommitment(ref offsetsCommitment, @op, true);
-
-    // transfer of chain 4
-    // encode_format = ["uint8","uint32","uint8","uint16","uint40","uint32","uint8","uint16"]
-    // example = [4, 1, 0, 33, 456, 4, 3, 34]
-    //
-    // data = [5316911983449149110179127749911773184]
-    // pending_data = 67305506
-    // pending_data_size = 4
-    let mut op = Bytes {
-        data: array![5316911983449149110179127749911773184],
-        pending_data: 67305506,
-        pending_data_size: 4
-    };
-    utils::paddingChunk(ref op, utils::OP_TRANSFER_CHUNKS);
-    pubdatas.concat(@op);
-    publicDataOffset += op.size();
-    utils::createOffsetCommitment(ref offsetsCommitment, @op, false);
-
-    // deposit of chain4
-    // encode_format = ["uint8","uint8","uint32","uint8","uint16","uint16","uint128","uint256"]
-    // example = [1, 4, 3, 6, 35, 35, 345, 0x74a0c0f8e8756218a96c2d9aae21152d786a0704202b10fb30496e46222b72d]
-    //
-    // data = [1349997183222710297597724425227075584, 379362818658190, 179892997260459296479640320015568236610]
-    // pending_data = 3254000107459431534606125
-    // pending_data_size = 11
-    let mut op = Bytes {
-        data: array![
-            1349997183222710297597724425227075584,
-            379362818658190,
-            179892997260459296479640320015568236610
-        ],
-        pending_data: 3254000107459431534606125,
-        pending_data_size: 11
-    };
-    utils::paddingChunk(ref op, utils::OP_DEPOSIT_CHUNKS);
-    pubdatas.concat(@op);
-    onchainOpPubdataHash4 = concatHash(onchainOpPubdataHash4, @op);
-    ops.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
-    publicDataOffset: publicDataOffset });
-    publicDataOffset += op.size();
-    utils::createOffsetCommitment(ref offsetsCommitment, @op, true);
-
-    // full exit of chain4
-    // encode_format = ["uint8","uint8","uint32","uint8","uint256","uint16","uint16","uint128"]
-    // example = [5, 4, 43, 2, 0x5D8E9F533DA8993FC200826F21D0b88F33f53c2a2a151016FD18dA7a77eEb0c, 35, 35, 245]
-    //
-    // data = [6666909166410712037873566033893757948, 42577624153754863967194330481103536495, 278544165408887043319642418119171899392]
-    // pending_data = 245
-    // pending_data_size = 11
-    let mut op = Bytes {
-        data: array![
-            6666909166410712037873566033893757948,
-            42577624153754863967194330481103536495,
-            278544165408887043319642418119171899392
-        ],
-        pending_data: 245,
-        pending_data_size: 11
-    };
-    utils::paddingChunk(ref op, utils::OP_FULL_EXIT_CHUNKS);
-    pubdatas.concat(@op);
-    onchainOpPubdataHash4 = concatHash(onchainOpPubdataHash4, @op);
-    ops.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
-    publicDataOffset: publicDataOffset });
-    publicDataOffset += op.size();
-    utils::createOffsetCommitment(ref offsetsCommitment, @op, true);
-
-    // mock Noop
-    // encode_format = ["uint8"]
-    // example = [0]
-    //
-    // data = []
-    // pending_data_size = 1
-    let mut op = Bytes { data: array![], pending_data: 1, pending_data_size: 1 };
-    utils::paddingChunk(ref op, utils::OP_NOOP_CHUNKS);
-    pubdatas.concat(@op);
-    publicDataOffset += op.size();
-    utils::createOffsetCommitment(ref offsetsCommitment, @op, false);
-
-    // force exit of chain3
-    // encode_format = ["uint8","uint8","uint32","uint8","uint32","uint32","uint8","uint16","uint16","uint128","uint256"]
-    // example = [7, 3, 30, 7, 3, 43, 2, 35, 35, 245, 0x74a0c0f8e8756218a96c2d9aae21152d786a0704202b10fb30496e46222b72d]
-    //
-    // data = [9320172861106316424366063172242647810, 181733163034406966250383145560965120, 19413155728529532836176956146393, 227142569737839188506614686513323349732]
-    // pending_data = 1646442285
-    // pending_data_size = 4
-    let mut op = Bytes {
-        data: array![
-            9320172861106316424366063172242647810,
-            181733163034406966250383145560965120,
-            19413155728529532836176956146393,
-            227142569737839188506614686513323349732
-        ],
-        pending_data: 1646442285,
-        pending_data_size: 4
-    };
-    utils::paddingChunk(ref op, utils::OP_FORCE_EXIT_CHUNKS);
-    pubdatas.concat(@op);
-    onchainOpPubdataHash3 = concatHash(onchainOpPubdataHash3, @op);
-    ops.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
-    publicDataOffset: publicDataOffset });
-    publicDataOffset += op.size();
     utils::createOffsetCommitment(ref offsetsCommitment, @op, true);
 
     // withdraw of current chain(chain 1)
@@ -1016,10 +699,18 @@ fn test_zklink_testCommitOneBlock_commit_compressed_block() {
     pubdatasOfChain1.concat(@op);
     onchainOpPubdataHash1 = concatHash(onchainOpPubdataHash1, @op);
     processableOpPubdataHash = concatHash(processableOpPubdataHash, @op);
-    ops.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
-    publicDataOffset: publicDataOffset });
-    opsOfChain1.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
-    publicDataOffset: publicDataOffsetOfChain1 });
+    ops
+        .append(
+            OnchainOperationData { // ethWitness: BytesTrait::new(),
+                publicDataOffset: publicDataOffset
+            }
+        );
+    opsOfChain1
+        .append(
+            OnchainOperationData { // ethWitness: BytesTrait::new(),
+                publicDataOffset: publicDataOffsetOfChain1
+            }
+        );
     publicDataOffset += op.size();
     publicDataOffsetOfChain1 += op.size();
     utils::createOffsetCommitment(ref offsetsCommitment, @op, true);
@@ -1061,10 +752,18 @@ fn test_zklink_testCommitOneBlock_commit_compressed_block() {
     pubdatasOfChain1.concat(@op);
     onchainOpPubdataHash1 = concatHash(onchainOpPubdataHash1, @op);
     processableOpPubdataHash = concatHash(processableOpPubdataHash, @op);
-    ops.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
-    publicDataOffset: publicDataOffset });
-    opsOfChain1.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
-    publicDataOffset: publicDataOffsetOfChain1 });
+    ops
+        .append(
+            OnchainOperationData { // ethWitness: BytesTrait::new(),
+                publicDataOffset: publicDataOffset
+            }
+        );
+    opsOfChain1
+        .append(
+            OnchainOperationData { // ethWitness: BytesTrait::new(),
+                publicDataOffset: publicDataOffsetOfChain1
+            }
+        );
     publicDataOffset += op.size();
     publicDataOffsetOfChain1 += op.size();
     priorityOperationsProcessed += 1;
@@ -1092,35 +791,19 @@ fn test_zklink_testCommitOneBlock_commit_compressed_block() {
     pubdatasOfChain1.concat(@op);
     onchainOpPubdataHash1 = concatHash(onchainOpPubdataHash1, @op);
     processableOpPubdataHash = concatHash(processableOpPubdataHash, @op);
-    ops.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
-    publicDataOffset: publicDataOffset });
-    opsOfChain1.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
-    publicDataOffset: publicDataOffsetOfChain1 });
+    ops
+        .append(
+            OnchainOperationData { // ethWitness: BytesTrait::new(),
+                publicDataOffset: publicDataOffset
+            }
+        );
+    opsOfChain1
+        .append(
+            OnchainOperationData { // ethWitness: BytesTrait::new(),
+                publicDataOffset: publicDataOffsetOfChain1
+            }
+        );
     publicDataOffset += op.size();
-    utils::createOffsetCommitment(ref offsetsCommitment, @op, true);
-
-    // withdraw of chain 4
-    // encode_format = ["uint8","uint8","uint32","uint8","uint16","uint16","uint128","uint16","uint256","uint32","uint16","uint8"]
-    // example = [3, 4, 15, 5, 34, 34, 1000, 33, 0x5D8E9F533DA8993FC200826F21D0b88F33f53c2a2a151016FD18dA7a77eEb0c, 14, 50, 0]
-    //
-    // data = [4008453174807044430802172532689469440, 1099512181807337, 325930098572440622605242809423852945235, 258714655159228338356975277813679521792]
-    // pending_data = 234893824
-    // pending_data_size = 4
-    let mut op = Bytes {
-        data: array![
-            4008453174807044430802172532689469440,
-            1099512181807337,
-            325930098572440622605242809423852945235,
-            258714655159228338356975277813679521792
-        ],
-        pending_data: 234893824,
-        pending_data_size: 4
-    };
-    utils::paddingChunk(ref op, utils::OP_WITHDRAW_CHUNKS);
-    pubdatas.concat(@op);
-    onchainOpPubdataHash4 = concatHash(onchainOpPubdataHash4, @op);
-    ops.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
-    publicDataOffset: publicDataOffset });
     utils::createOffsetCommitment(ref offsetsCommitment, @op, true);
 
     let preBlock = StoredBlockInfo {
@@ -1133,31 +816,15 @@ fn test_zklink_testCommitOneBlock_commit_compressed_block() {
         syncHash: 4
     };
 
-    let extraBlock = CompressedBlockExtraInfo {
-        publicDataHash: 0, offsetCommitmentHash: 0, onchainOperationPubdataHashs: array![]
-    };
-
-    let mut commitBlock = CommitBlockInfo {
-        newStateHash: 5,
-        publicData: BytesTrait::new(),
-        timestamp: 1652422395,
-        onchainOperations: array![],
-        blockNumber: 11,
-        feeAccount: 0
-    };
-    commitBlock.timestamp = preBlock.timestamp + 1;
-    commitBlock.publicData = pubdatas.clone();
-    commitBlock.onchainOperations = ops;
-
-    let r0: StoredBlockInfo = dispatcher
-        .testCommitOneBlock(preBlock, commitBlock, false, extraBlock);
-
+    let blockNumber = 11;
+    let timestamp = 1652422396;
+    let newStateHash = 5;
     let compressedBlock = CommitBlockInfo {
-        newStateHash: 5,
+        newStateHash: newStateHash,
         publicData: pubdatasOfChain1,
-        timestamp: 1652422396,
+        timestamp: timestamp,
         onchainOperations: opsOfChain1,
-        blockNumber: 11,
+        blockNumber: blockNumber,
         feeAccount: 0
     };
 
@@ -1165,22 +832,20 @@ fn test_zklink_testCommitOneBlock_commit_compressed_block() {
         publicDataHash: pubdatas.keccak(),
         offsetCommitmentHash: offsetsCommitment.keccak(),
         onchainOperationPubdataHashs: array![
-            0,
-            onchainOpPubdataHash1,
-            EMPTY_STRING_KECCAK,
-            onchainOpPubdataHash3,
-            onchainOpPubdataHash4
+            0, onchainOpPubdataHash1, EMPTY_STRING_KECCAK, EMPTY_STRING_KECCAK, EMPTY_STRING_KECCAK
         ]
     };
 
-    let r1: StoredBlockInfo = dispatcher
-        .testCommitOneBlock(preBlock, compressedBlock, true, extraBlock);
+    let commitment = createBlockCommitment(@preBlock, @compressedBlock, @extraBlock);
 
-    assert(r1.blockNumber == r0.blockNumber, 'invaid value1');
-    assert(r1.priorityOperations == r0.priorityOperations, 'invaid value2');
-    assert(r1.pendingOnchainOperationsHash == r0.pendingOnchainOperationsHash, 'invaid value3');
-    assert(r1.timestamp == r0.timestamp, 'invaid value4');
-    assert(r1.stateHash == r0.stateHash, 'invaid value5');
-    assert(r1.commitment == r0.commitment, 'invaid value6');
-    assert(r1.syncHash == r0.syncHash, 'invaid value7');
+    let r1: StoredBlockInfo = dispatcher.testCommitOneBlock(preBlock, compressedBlock, extraBlock);
+
+    assert(r1.blockNumber == blockNumber, 'invaid value1');
+    assert(r1.priorityOperations == priorityOperationsProcessed, 'invaid value2');
+    assert(r1.pendingOnchainOperationsHash == processableOpPubdataHash, 'invaid value3');
+    assert(r1.timestamp == timestamp, 'invaid value4');
+    assert(r1.stateHash == newStateHash, 'invaid value5');
+    assert(r1.commitment == commitment, 'invaid value6');
+    assert(r1.syncHash.low == 0xf592534d947803bd7707e40ec34a185b, 'invaid value7');
+    assert(r1.syncHash.high == 0x415190de4c2749e44e1565072210a8fa, 'invaid value7');
 }

--- a/src/tests/test_block_commit.cairo
+++ b/src/tests/test_block_commit.cairo
@@ -121,9 +121,8 @@ fn test_zklink_collectOnchainOps_invalid_pubdata_offset1() {
     publicData.append_u8(0x00);
     utils::paddingChunk(ref publicData, utils::OP_NOOP_CHUNKS);
 
-    let onchainOperation = OnchainOperationData {
-        ethWitness: BytesTrait::new(), publicDataOffset: publicData.size()
-    };
+    let onchainOperation = OnchainOperationData { // ethWitness: BytesTrait::new(),
+    publicDataOffset: publicData.size() };
     let onchainOperations: Array<OnchainOperationData> = array![onchainOperation];
 
     let mut block = CommitBlockInfo {
@@ -150,9 +149,8 @@ fn test_zklink_collectOnchainOps_invalid_pubdata_offset2() {
     publicData.append_u8(0x00);
     utils::paddingChunk(ref publicData, utils::OP_NOOP_CHUNKS);
 
-    let onchainOperation = OnchainOperationData {
-        ethWitness: BytesTrait::new(), publicDataOffset: 1
-    };
+    let onchainOperation = OnchainOperationData { // ethWitness: BytesTrait::new(),
+    publicDataOffset: 1 };
     let onchainOperations: Array<OnchainOperationData> = array![onchainOperation];
 
     let mut block = CommitBlockInfo {
@@ -179,9 +177,8 @@ fn test_zklink_collectOnchainOps_invalid_pubdata_offset3() {
     publicData.append_u8(0x00);
     utils::paddingChunk(ref publicData, utils::OP_NOOP_CHUNKS);
 
-    let onchainOperation = OnchainOperationData {
-        ethWitness: BytesTrait::new(), publicDataOffset: CHUNK_BYTES - 2
-    };
+    let onchainOperation = OnchainOperationData { // ethWitness: BytesTrait::new(),
+    publicDataOffset: CHUNK_BYTES - 2 };
     let onchainOperations: Array<OnchainOperationData> = array![onchainOperation];
 
     let mut block = CommitBlockInfo {
@@ -208,9 +205,8 @@ fn test_zklink_collectOnchainOps_invalid_op_type() {
     publicData.append_u16(0x0001);
     utils::paddingChunk(ref publicData, utils::OP_NOOP_CHUNKS);
 
-    let onchainOperation = OnchainOperationData {
-        ethWitness: BytesTrait::new(), publicDataOffset: 0
-    };
+    let onchainOperation = OnchainOperationData { // ethWitness: BytesTrait::new(),
+    publicDataOffset: 0 };
     let onchainOperations: Array<OnchainOperationData> = array![onchainOperation];
 
     let mut block = CommitBlockInfo {
@@ -262,9 +258,8 @@ fn test_zklink_collectOnchainOps_invalid_chain_id1() {
 
     utils::paddingChunk(ref publicData, utils::OP_DEPOSIT_CHUNKS);
 
-    let onchainOperation = OnchainOperationData {
-        ethWitness: BytesTrait::new(), publicDataOffset: 0
-    };
+    let onchainOperation = OnchainOperationData { // ethWitness: BytesTrait::new(),
+    publicDataOffset: 0 };
     let onchainOperations: Array<OnchainOperationData> = array![onchainOperation];
 
     let mut block = CommitBlockInfo {
@@ -305,9 +300,8 @@ fn test_zklink_collectOnchainOps_invalid_chain_id2() {
     };
     utils::paddingChunk(ref publicData, utils::OP_DEPOSIT_CHUNKS);
 
-    let onchainOperation = OnchainOperationData {
-        ethWitness: BytesTrait::new(), publicDataOffset: 0
-    };
+    let onchainOperation = OnchainOperationData { // ethWitness: BytesTrait::new(),
+    publicDataOffset: 0 };
     let onchainOperations: Array<OnchainOperationData> = array![onchainOperation];
 
     let mut block = CommitBlockInfo {
@@ -362,8 +356,9 @@ fn test_zklink_collectOnchainOps_duplicate_pubdata_offset() {
     depositData0.concat(@depositData1);
 
     let onchainOperations: Array<OnchainOperationData> = array![
-        OnchainOperationData { ethWitness: BytesTrait::new(), publicDataOffset: 0 },
-        OnchainOperationData { ethWitness: BytesTrait::new(), publicDataOffset: 0 }
+        OnchainOperationData { // ethWitness: BytesTrait::new(),
+        publicDataOffset: 0 }, OnchainOperationData { // ethWitness: BytesTrait::new(),
+        publicDataOffset: 0 }
     ];
 
     let mut block = CommitBlockInfo {
@@ -435,18 +430,10 @@ fn test_zklink_collectOnchainOps_success() {
     pubdatas.concat(@op);
     pubdatasOfChain1.concat(@op);
     onchainOpPubdataHash1 = concatHash(onchainOpPubdataHash1, @op);
-    ops
-        .append(
-            OnchainOperationData {
-                ethWitness: BytesTrait::new(), publicDataOffset: publicDataOffset
-            }
-        );
-    opsOfChain1
-        .append(
-            OnchainOperationData {
-                ethWitness: BytesTrait::new(), publicDataOffset: publicDataOffsetOfChain1
-            }
-        );
+    ops.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
+    publicDataOffset: publicDataOffset });
+    opsOfChain1.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
+    publicDataOffset: publicDataOffsetOfChain1 });
     publicDataOffset += op.size();
     publicDataOffsetOfChain1 += op.size();
     priorityOperationsProcessed += 1;
@@ -472,12 +459,8 @@ fn test_zklink_collectOnchainOps_success() {
     utils::paddingChunk(ref op, utils::OP_CHANGE_PUBKEY_CHUNKS);
     pubdatas.concat(@op);
     onchainOpPubdataHash3 = concatHash(onchainOpPubdataHash3, @op);
-    ops
-        .append(
-            OnchainOperationData {
-                ethWitness: BytesTrait::new(), publicDataOffset: publicDataOffset
-            }
-        );
+    ops.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
+    publicDataOffset: publicDataOffset });
     publicDataOffset += op.size();
     utils::createOffsetCommitment(ref offsetsCommitment, @op, true);
 
@@ -517,12 +500,8 @@ fn test_zklink_collectOnchainOps_success() {
     utils::paddingChunk(ref op, utils::OP_DEPOSIT_CHUNKS);
     pubdatas.concat(@op);
     onchainOpPubdataHash4 = concatHash(onchainOpPubdataHash4, @op);
-    ops
-        .append(
-            OnchainOperationData {
-                ethWitness: BytesTrait::new(), publicDataOffset: publicDataOffset
-            }
-        );
+    ops.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
+    publicDataOffset: publicDataOffset });
     publicDataOffset += op.size();
     utils::createOffsetCommitment(ref offsetsCommitment, @op, true);
 
@@ -545,12 +524,8 @@ fn test_zklink_collectOnchainOps_success() {
     utils::paddingChunk(ref op, utils::OP_FULL_EXIT_CHUNKS);
     pubdatas.concat(@op);
     onchainOpPubdataHash4 = concatHash(onchainOpPubdataHash4, @op);
-    ops
-        .append(
-            OnchainOperationData {
-                ethWitness: BytesTrait::new(), publicDataOffset: publicDataOffset
-            }
-        );
+    ops.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
+    publicDataOffset: publicDataOffset });
     publicDataOffset += op.size();
     utils::createOffsetCommitment(ref offsetsCommitment, @op, true);
 
@@ -586,12 +561,8 @@ fn test_zklink_collectOnchainOps_success() {
     utils::paddingChunk(ref op, utils::OP_FORCE_EXIT_CHUNKS);
     pubdatas.concat(@op);
     onchainOpPubdataHash3 = concatHash(onchainOpPubdataHash3, @op);
-    ops
-        .append(
-            OnchainOperationData {
-                ethWitness: BytesTrait::new(), publicDataOffset: publicDataOffset
-            }
-        );
+    ops.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
+    publicDataOffset: publicDataOffset });
     publicDataOffset += op.size();
     utils::createOffsetCommitment(ref offsetsCommitment, @op, true);
 
@@ -617,18 +588,10 @@ fn test_zklink_collectOnchainOps_success() {
     pubdatasOfChain1.concat(@op);
     onchainOpPubdataHash1 = concatHash(onchainOpPubdataHash1, @op);
     processableOpPubdataHash = concatHash(processableOpPubdataHash, @op);
-    ops
-        .append(
-            OnchainOperationData {
-                ethWitness: BytesTrait::new(), publicDataOffset: publicDataOffset
-            }
-        );
-    opsOfChain1
-        .append(
-            OnchainOperationData {
-                ethWitness: BytesTrait::new(), publicDataOffset: publicDataOffsetOfChain1
-            }
-        );
+    ops.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
+    publicDataOffset: publicDataOffset });
+    opsOfChain1.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
+    publicDataOffset: publicDataOffsetOfChain1 });
     publicDataOffset += op.size();
     publicDataOffsetOfChain1 += op.size();
     utils::createOffsetCommitment(ref offsetsCommitment, @op, true);
@@ -670,18 +633,10 @@ fn test_zklink_collectOnchainOps_success() {
     pubdatasOfChain1.concat(@op);
     onchainOpPubdataHash1 = concatHash(onchainOpPubdataHash1, @op);
     processableOpPubdataHash = concatHash(processableOpPubdataHash, @op);
-    ops
-        .append(
-            OnchainOperationData {
-                ethWitness: BytesTrait::new(), publicDataOffset: publicDataOffset
-            }
-        );
-    opsOfChain1
-        .append(
-            OnchainOperationData {
-                ethWitness: BytesTrait::new(), publicDataOffset: publicDataOffsetOfChain1
-            }
-        );
+    ops.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
+    publicDataOffset: publicDataOffset });
+    opsOfChain1.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
+    publicDataOffset: publicDataOffsetOfChain1 });
     publicDataOffset += op.size();
     publicDataOffsetOfChain1 += op.size();
     priorityOperationsProcessed += 1;
@@ -709,18 +664,10 @@ fn test_zklink_collectOnchainOps_success() {
     pubdatasOfChain1.concat(@op);
     onchainOpPubdataHash1 = concatHash(onchainOpPubdataHash1, @op);
     processableOpPubdataHash = concatHash(processableOpPubdataHash, @op);
-    ops
-        .append(
-            OnchainOperationData {
-                ethWitness: BytesTrait::new(), publicDataOffset: publicDataOffset
-            }
-        );
-    opsOfChain1
-        .append(
-            OnchainOperationData {
-                ethWitness: BytesTrait::new(), publicDataOffset: publicDataOffsetOfChain1
-            }
-        );
+    ops.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
+    publicDataOffset: publicDataOffset });
+    opsOfChain1.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
+    publicDataOffset: publicDataOffsetOfChain1 });
     publicDataOffset += op.size();
     utils::createOffsetCommitment(ref offsetsCommitment, @op, true);
 
@@ -744,12 +691,8 @@ fn test_zklink_collectOnchainOps_success() {
     utils::paddingChunk(ref op, utils::OP_WITHDRAW_CHUNKS);
     pubdatas.concat(@op);
     onchainOpPubdataHash4 = concatHash(onchainOpPubdataHash4, @op);
-    ops
-        .append(
-            OnchainOperationData {
-                ethWitness: BytesTrait::new(), publicDataOffset: publicDataOffset
-            }
-        );
+    ops.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
+    publicDataOffset: publicDataOffset });
     utils::createOffsetCommitment(ref offsetsCommitment, @op, true);
 
     let mut block = CommitBlockInfo {
@@ -915,18 +858,10 @@ fn test_zklink_testCommitOneBlock_commit_compressed_block() {
     pubdatas.concat(@op);
     pubdatasOfChain1.concat(@op);
     onchainOpPubdataHash1 = concatHash(onchainOpPubdataHash1, @op);
-    ops
-        .append(
-            OnchainOperationData {
-                ethWitness: BytesTrait::new(), publicDataOffset: publicDataOffset
-            }
-        );
-    opsOfChain1
-        .append(
-            OnchainOperationData {
-                ethWitness: BytesTrait::new(), publicDataOffset: publicDataOffsetOfChain1
-            }
-        );
+    ops.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
+    publicDataOffset: publicDataOffset });
+    opsOfChain1.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
+    publicDataOffset: publicDataOffsetOfChain1 });
     publicDataOffset += op.size();
     publicDataOffsetOfChain1 += op.size();
     priorityOperationsProcessed += 1;
@@ -952,12 +887,8 @@ fn test_zklink_testCommitOneBlock_commit_compressed_block() {
     utils::paddingChunk(ref op, utils::OP_CHANGE_PUBKEY_CHUNKS);
     pubdatas.concat(@op);
     onchainOpPubdataHash3 = concatHash(onchainOpPubdataHash3, @op);
-    ops
-        .append(
-            OnchainOperationData {
-                ethWitness: BytesTrait::new(), publicDataOffset: publicDataOffset
-            }
-        );
+    ops.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
+    publicDataOffset: publicDataOffset });
     publicDataOffset += op.size();
     utils::createOffsetCommitment(ref offsetsCommitment, @op, true);
 
@@ -997,12 +928,8 @@ fn test_zklink_testCommitOneBlock_commit_compressed_block() {
     utils::paddingChunk(ref op, utils::OP_DEPOSIT_CHUNKS);
     pubdatas.concat(@op);
     onchainOpPubdataHash4 = concatHash(onchainOpPubdataHash4, @op);
-    ops
-        .append(
-            OnchainOperationData {
-                ethWitness: BytesTrait::new(), publicDataOffset: publicDataOffset
-            }
-        );
+    ops.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
+    publicDataOffset: publicDataOffset });
     publicDataOffset += op.size();
     utils::createOffsetCommitment(ref offsetsCommitment, @op, true);
 
@@ -1025,12 +952,8 @@ fn test_zklink_testCommitOneBlock_commit_compressed_block() {
     utils::paddingChunk(ref op, utils::OP_FULL_EXIT_CHUNKS);
     pubdatas.concat(@op);
     onchainOpPubdataHash4 = concatHash(onchainOpPubdataHash4, @op);
-    ops
-        .append(
-            OnchainOperationData {
-                ethWitness: BytesTrait::new(), publicDataOffset: publicDataOffset
-            }
-        );
+    ops.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
+    publicDataOffset: publicDataOffset });
     publicDataOffset += op.size();
     utils::createOffsetCommitment(ref offsetsCommitment, @op, true);
 
@@ -1066,12 +989,8 @@ fn test_zklink_testCommitOneBlock_commit_compressed_block() {
     utils::paddingChunk(ref op, utils::OP_FORCE_EXIT_CHUNKS);
     pubdatas.concat(@op);
     onchainOpPubdataHash3 = concatHash(onchainOpPubdataHash3, @op);
-    ops
-        .append(
-            OnchainOperationData {
-                ethWitness: BytesTrait::new(), publicDataOffset: publicDataOffset
-            }
-        );
+    ops.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
+    publicDataOffset: publicDataOffset });
     publicDataOffset += op.size();
     utils::createOffsetCommitment(ref offsetsCommitment, @op, true);
 
@@ -1097,18 +1016,10 @@ fn test_zklink_testCommitOneBlock_commit_compressed_block() {
     pubdatasOfChain1.concat(@op);
     onchainOpPubdataHash1 = concatHash(onchainOpPubdataHash1, @op);
     processableOpPubdataHash = concatHash(processableOpPubdataHash, @op);
-    ops
-        .append(
-            OnchainOperationData {
-                ethWitness: BytesTrait::new(), publicDataOffset: publicDataOffset
-            }
-        );
-    opsOfChain1
-        .append(
-            OnchainOperationData {
-                ethWitness: BytesTrait::new(), publicDataOffset: publicDataOffsetOfChain1
-            }
-        );
+    ops.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
+    publicDataOffset: publicDataOffset });
+    opsOfChain1.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
+    publicDataOffset: publicDataOffsetOfChain1 });
     publicDataOffset += op.size();
     publicDataOffsetOfChain1 += op.size();
     utils::createOffsetCommitment(ref offsetsCommitment, @op, true);
@@ -1150,18 +1061,10 @@ fn test_zklink_testCommitOneBlock_commit_compressed_block() {
     pubdatasOfChain1.concat(@op);
     onchainOpPubdataHash1 = concatHash(onchainOpPubdataHash1, @op);
     processableOpPubdataHash = concatHash(processableOpPubdataHash, @op);
-    ops
-        .append(
-            OnchainOperationData {
-                ethWitness: BytesTrait::new(), publicDataOffset: publicDataOffset
-            }
-        );
-    opsOfChain1
-        .append(
-            OnchainOperationData {
-                ethWitness: BytesTrait::new(), publicDataOffset: publicDataOffsetOfChain1
-            }
-        );
+    ops.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
+    publicDataOffset: publicDataOffset });
+    opsOfChain1.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
+    publicDataOffset: publicDataOffsetOfChain1 });
     publicDataOffset += op.size();
     publicDataOffsetOfChain1 += op.size();
     priorityOperationsProcessed += 1;
@@ -1189,18 +1092,10 @@ fn test_zklink_testCommitOneBlock_commit_compressed_block() {
     pubdatasOfChain1.concat(@op);
     onchainOpPubdataHash1 = concatHash(onchainOpPubdataHash1, @op);
     processableOpPubdataHash = concatHash(processableOpPubdataHash, @op);
-    ops
-        .append(
-            OnchainOperationData {
-                ethWitness: BytesTrait::new(), publicDataOffset: publicDataOffset
-            }
-        );
-    opsOfChain1
-        .append(
-            OnchainOperationData {
-                ethWitness: BytesTrait::new(), publicDataOffset: publicDataOffsetOfChain1
-            }
-        );
+    ops.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
+    publicDataOffset: publicDataOffset });
+    opsOfChain1.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
+    publicDataOffset: publicDataOffsetOfChain1 });
     publicDataOffset += op.size();
     utils::createOffsetCommitment(ref offsetsCommitment, @op, true);
 
@@ -1224,12 +1119,8 @@ fn test_zklink_testCommitOneBlock_commit_compressed_block() {
     utils::paddingChunk(ref op, utils::OP_WITHDRAW_CHUNKS);
     pubdatas.concat(@op);
     onchainOpPubdataHash4 = concatHash(onchainOpPubdataHash4, @op);
-    ops
-        .append(
-            OnchainOperationData {
-                ethWitness: BytesTrait::new(), publicDataOffset: publicDataOffset
-            }
-        );
+    ops.append(OnchainOperationData { // ethWitness: BytesTrait::new(),
+    publicDataOffset: publicDataOffset });
     utils::createOffsetCommitment(ref offsetsCommitment, @op, true);
 
     let preBlock = StoredBlockInfo {

--- a/src/tests/test_utils.cairo
+++ b/src/tests/test_utils.cairo
@@ -1,39 +1,9 @@
 use array::ArrayTrait;
 use zklink::utils::utils::{
-    u8_array_to_u256, u128_array_slice, u64_array_slice, concatHash, concatTwoHash, pubKeyHash,
-    update_u256_array_at
+    u8_array_to_u256, u128_array_slice, u64_array_slice, concatHash, concatTwoHash, pubKeyHash
 };
 use zklink::utils::bytes::{Bytes, BytesTrait};
 use debug::PrintTrait;
-
-#[test]
-#[available_gas(20000000000)]
-fn test_update_u256_array_at() {
-    let array: Array<u256> = array![1, 2, 3, 4, 5];
-    let array = update_u256_array_at(@array, 0, 6);
-    assert(array.len() == 5, 'invalid length');
-    assert(array[0] == @6, 'invalid value');
-    assert(array[1] == @2, 'invalid value');
-    assert(array[2] == @3, 'invalid value');
-    assert(array[3] == @4, 'invalid value');
-    assert(array[4] == @5, 'invalid value');
-
-    let array = update_u256_array_at(@array, 1, 7);
-    assert(array.len() == 5, 'invalid length');
-    assert(array[0] == @6, 'invalid value');
-    assert(array[1] == @7, 'invalid value');
-    assert(array[2] == @3, 'invalid value');
-    assert(array[3] == @4, 'invalid value');
-    assert(array[4] == @5, 'invalid value');
-
-    let array = update_u256_array_at(@array, 4, 9);
-    assert(array.len() == 5, 'invalid length');
-    assert(array[0] == @6, 'invalid value');
-    assert(array[1] == @7, 'invalid value');
-    assert(array[2] == @3, 'invalid value');
-    assert(array[3] == @4, 'invalid value');
-    assert(array[4] == @9, 'invalid value');
-}
 
 
 #[test]

--- a/src/utils/data_structures.cairo
+++ b/src/utils/data_structures.cairo
@@ -61,7 +61,7 @@ mod DataStructures {
     // Onchain operations is operations that need some processing on L1: Deposits, Withdrawals, ChangePubKey.
     #[derive(Drop, Serde)]
     struct OnchainOperationData {
-        ethWitness: Bytes, // Some external data that can be needed for operation processing
+        // ethWitness: Bytes, // Some external data that can be needed for operation processing
         publicDataOffset: usize // Byte offset in public data for onchain operation
     }
 

--- a/src/utils/utils.cairo
+++ b/src/utils/utils.cairo
@@ -7,25 +7,6 @@ use zklink::utils::bytes::{Bytes, BytesTrait};
 use zklink::utils::keccak::keccak_u128s_be;
 use alexandria_data_structures::array_ext::ArrayTraitExt;
 
-fn update_u256_array_at(arr: @Array<u256>, index: usize, value: u256) -> Array<u256> {
-    assert(index < arr.len(), 'index out of range');
-    let mut new_arr: Array<u256> = array![];
-    let mut i = 0;
-
-    loop {
-        if i == arr.len() {
-            break ();
-        }
-        if i == index {
-            new_arr.append(value);
-        } else {
-            new_arr.append(*arr[i]);
-        }
-        i += 1;
-    };
-    new_arr
-}
-
 // Convert sha256 result(Array<u8>) to u256
 // result length MUST be 32
 fn u8_array_to_u256(arr: Span<u8>) -> u256 {


### PR DESCRIPTION
fix #98 
- replace commitment from sha256 to keccak256
- remove ethWitness from OnchainOperationData
- remove commitBlocks, only support commitCompressedBlocks